### PR TITLE
Allow destroy powertip of an element

### DIFF
--- a/jquery.powertip.js
+++ b/jquery.powertip.js
@@ -65,7 +65,7 @@
 			return this.off('.powertip').each(function destroy() {
 				var $this = $(this);
 
-				if (!$this.attr('originalTitle')) {
+				if ($this.data('originalTitle')) {
 					$this.attr('title', $this.data('originalTitle'));
 				}
 


### PR DESCRIPTION
Sometimes you need to be able to unbind poertip from an element
completely, this patch allows call `$el.powerTip('destroy')` to
remove powertip listeners and associated data attributes:

```
$('#myTip').powerTip('destroy');
```
