### PR TITLE
Bugfix: Accept function for .data('powertipjq')

### DIFF
--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -395,7 +395,7 @@ function TooltipController(options) {
 			}
 			content = tipText;
 		} else if (tipObject) {
-			if (typeof tipElem === 'function') {
+			if (typeof tipObject === 'function') {
 				tipObject = tipObject.call(element[0]);
 			}
 			if (tipObject.length > 0) {


### PR DESCRIPTION
`typeof` statements are one of the few places where JS interpreters won't throw a reference error for an undeclared variable, or this would have been caught much sooner.
