### PR TITLE
Added 'keepAlive' option that prevents PowerTip from being hidden on mouseleave events

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ These are general guidelines, not rules. I won't refuse a pull request just beca
 	* PowerTip will now use right position for right aligned tooltips.
 	* Data attributes powertip and powertipjq now accept a function.
 	* powerTip() will now overwrite any previous powerTip() calls on an element.
+	* Added keepAlive option to prevent automatic hiding of tooltips on mouseleave events.
 * **API**
 	* Added show() and hide() methods to the API.
 	* Added reposition() method to the API.

--- a/doc/README.md
+++ b/doc/README.md
@@ -208,6 +208,7 @@ Of course those defaults will be overridden with any options you pass directly t
 | `intentPollInterval` | `100` | Number | Hover intent polling interval in milliseconds. |
 | `intentSensitivity` | `7` | Number | Hover intent sensitivity. The tooltip will not open unless the number of pixels the mouse has moved within the `intentPollInterval` is less than this value. These default values mean that if the mouse cursor has moved 7 or more pixels in 100 milliseconds the tooltip will not open. |
 | `manual` | `false` | Boolean | If set to `true` then PowerTip will not hook up its event handlers, letting you create your own event handlers to control when tooltips are shown (using the API to open and close tooltips). |
+| `keepAlive` | `false` | Boolean | If set to `true` then the tooltip will stay visible until manually closed or destroyed using the API or another PowerTip instance is shown. Only works if `followMouse` is set to `false`. |
 
 ## Tooltip CSS
 

--- a/examples/examples.html
+++ b/examples/examples.html
@@ -9,6 +9,7 @@
 		#placement-examples .east { margin-left: 450px; }
 		#mousefollow-examples div { background-color: #EEE; text-align: center; line-height: 400px; margin: 0 auto; height: 400px; width: 100%; }
 		#mouseon-examples div { background-color: #EEE; text-align: center; width: 400px; padding: 40px; }
+		#keepalive-examples div { background-color: #EEE; text-align: center; width: 400px; padding: 40px; }
 		#api-examples input { margin: 10px; padding: 10px 30px; }
 	</style>
 	<!-- Include jQuery and PowerTip -->
@@ -94,6 +95,28 @@
 			mouseOnDiv.powerTip({
 				placement: 'e',
 				mouseOnToPopup: true
+			});
+		});
+	</script>
+	
+	<!-- Keep alive examples -->
+	<div id="keepalive-examples">
+		<h2>Keep alive example</h2>
+		<div>
+			The PowerTip for this box will stay visible when the mouse leaves the box.
+		</div>
+	</div>
+	<script type="text/javascript">
+		$(function() {
+			// keep-alive example
+			var keepAliveDiv = $('#keepalive-examples div');
+			var keepAliveContent = $(
+				'<div>You can hide me manually using the API</div><div>or by activating another PowerTip instance</div>'
+			);
+			keepAliveDiv.data('powertipjq', keepAliveContent);
+			keepAliveDiv.powerTip({
+				placement: 'e',
+				keepAlive: true
 			});
 		});
 	</script>

--- a/src/core.js
+++ b/src/core.js
@@ -123,14 +123,20 @@ $.fn.powerTip = function(opts, arg) {
 				$.powerTip.show(this, event);
 			},
 			'mouseleave.powertip': function elementMouseLeave() {
-				$.powerTip.hide(this);
+				// hide on mouseleave unless keepAlive option is enabled
+				if(!options.keepAlive){
+					$.powerTip.hide(this);
+				}
 			},
 			// keyboard events
 			'focus.powertip': function elementFocus() {
 				$.powerTip.show(this);
 			},
 			'blur.powertip': function elementBlur() {
-				$.powerTip.hide(this, true);
+				// hide on mouseleave unless keepAlive option is enabled
+				if(!options.keepAlive){
+					$.powerTip.hide(this, true);
+				}
 			},
 			'keydown.powertip': function elementKeyDown(event) {
 				// close tooltip when the escape key is pressed
@@ -159,7 +165,8 @@ $.fn.powerTip.defaults = {
 	smartPlacement: false,
 	offset: 10,
 	mouseOnToPopup: false,
-	manual: false
+	manual: false,
+	keepAlive: false
 };
 
 /**

--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -57,7 +57,8 @@ function TooltipController(options) {
 			mouseleave: function tipMouseLeave() {
 				// check activeHover in case the mouse cursor entered the
 				// tooltip during the fadeOut and close cycle
-				if (session.activeHover) {
+				// and check if keepAlive option is enabled
+				if (session.activeHover && !options.keepAlive) {
 					session.activeHover.data(DATA_DISPLAYCONTROLLER).hide();
 				}
 			}
@@ -367,7 +368,7 @@ function TooltipController(options) {
 				}
 			}
 
-			if (isDesynced) {
+			if (isDesynced && !options.keepAlive) {
 				// close the desynced tip
 				hideTip(session.activeHover);
 			}


### PR DESCRIPTION
This is a simple option that if set to true keeps the PowerTip instance visible even when the mouse leaves the trigger element (and also the tooltip content).

I don't know if this will be especially useful for other people, but in some of my use cases I am manually activating PowerTips on a click event and would like to keep them visible until they are manually closed (with another click event for example, or when a different tooltip instance is shown). I know this overlaps mouseOnToPopup a bit, in that it also provides the ability to interact with the tooltip content. But it seemed like the simplest implementation for a slightly different behavior.
