### PR TITLE
Set popupClass before tooltip positioning

### DIFF
--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -105,6 +105,9 @@ function TooltipController(options) {
 
 		tipElement.data(DATA_MOUSEONTOTIP, options.mouseOnToPopup);
 
+		// add custom class to tooltip element
+		tipElement.addClass(options.popupClass);
+
 		// set tooltip position
 		if (!options.followMouse) {
 			positionTipOnElement(element);
@@ -112,9 +115,6 @@ function TooltipController(options) {
 		} else {
 			positionTipOnCursor();
 		}
-
-		// add custom class to tooltip element
-		tipElement.addClass(options.popupClass);
 
 		// close tooltip when clicking anywhere on the page, with the exception
 		// of the tooltip's trigger element and any elements that are within a


### PR DESCRIPTION
Is there any reason why popupClass is applied after tooltip positioning? I'm not sure, but I see one disadvantage of this - when popupClass contains a width attribute:
- tooltip is placed correctly (depends on its current width)
- a new classs is applied, thus tooltip's width is changed (now tooltip placed incorrectly)

This problem can be fixed easily, if we will apply popupClass before.
