### PR TITLE
Added verification before removeClass

### DIFF
--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -192,6 +192,10 @@ function TooltipController(options) {
 
 		// fade out
 		tipElement.fadeOut(options.fadeOutTime, function fadeOutCallback() {
+			if (session.isTipOpen) {
+				return;
+			}
+
 			var coords = new CSSCoordinates();
 
 			// reset session and tooltip element


### PR DESCRIPTION
I'm not 100% sure (because I have quite complex code to reproduce this), but it looks like sometimes `fadeOut` function can be executed after tooltip reopening, if time interval between `closed` and `reopened` tooltip states are small enought. It leads to the appearing of unstyled tooltip on page, so we need to check this situation.
