### PR TITLE
Add reposition fix

### DIFF
--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -304,6 +304,7 @@ function TooltipController(options) {
 		}
 
 		// add placement as class for CSS arrows
+		tipElement.removeClass('w nw sw e ne se n s w se-alt sw-alt ne-alt nw-alt');
 		tipElement.addClass(finalPlacement);
 	}
 

--- a/test/edge-cases.html
+++ b/test/edge-cases.html
@@ -58,9 +58,9 @@
 		header, section { margin-bottom: 20px; }
 		section { border: 1px solid #CCC; margin: 20px; padding: 20px; }
 		#powerTip { white-space: normal; }
-		#huge-text div, #huge-text-smart div { text-align: center; }
-		#huge-text input, #huge-text-smart input { margin: 10px; padding: 10px; }
-		#huge-text .east, #huge-text-smart .east { margin-left: 450px; }
+		#huge-text div, #huge-text-smart div, #huge-text-smart-reposition div  { text-align: center; }
+		#huge-text input, #huge-text-smart input, #huge-text-smart-reposition input { margin: 10px; padding: 10px; }
+		#huge-text .east, #huge-text-smart .east, #huge-text-smart-reposition .east { margin-left: 450px; }
 		svg { display: block; margin: 0 auto; }
 		#session { position: fixed; right: 10px; top: 10px; font-size: 10px; width: 160px; background-color: #fff; border: 1px solid #ccc; padding: 10px; overflow: hidden; }
 		#session pre { margin: 0; }
@@ -143,6 +143,24 @@
 	<section id="huge-text-smart">
 		<h2>Huge Text with Smart Placement</h2>
 		<p>The tooltips for the buttons below have a lot of text. The tooltip div is completely elastic for this demo. The tooltips should be properly placed when they render.</p>
+		<div>
+			<input type="button" class="north-west-alt" value="North West Alt" />
+			<input type="button" class="north-west" value="North West" />
+			<input type="button" class="north" value="North" />
+			<input type="button" class="north-east" value="North East" />
+			<input type="button" class="north-east-alt" value="North East Alt" /><br />
+			<input type="button" class="west" value="West" />
+			<input type="button" class="east" value="East" /><br />
+			<input type="button" class="south-west-alt" value="South West Alt" />
+			<input type="button" class="south-west" value="South West" />
+			<input type="button" class="south" value="South" />
+			<input type="button" class="south-east" value="South East" />
+			<input type="button" class="south-east-alt" value="South East Alt" />
+		</div>
+	</section>
+	<section id="huge-text-smart-reposition">
+		<h2>Changing powertip placement after reposition call</h2>
+		<p>The tooltips for the buttons below will have a lot of text inserted into them after 1 second and repositioned with smart placement. In the case that the tooltip placement changes, the tooltip should display correctly. </p>
 		<div>
 			<input type="button" class="north-west-alt" value="North West Alt" />
 			<input type="button" class="north-west" value="North West" />

--- a/test/tests-edge.js
+++ b/test/tests-edge.js
@@ -114,6 +114,46 @@ $(function() {
 	$('#huge-text-smart .south-west-alt').powerTip({ placement: 'sw-alt', smartPlacement: true });
 	$('#huge-text-smart .south-east-alt').powerTip({ placement: 'se-alt', smartPlacement: true });
 
+	$.each(
+		[
+			'north',
+			'east',
+			'south',
+			'west',
+			'north-west',
+			'north-east',
+			'south-west',
+			'south-east',
+			'north-west-alt',
+			'north-east-alt',
+			'south-west-alt',
+			'south-east-alt'
+		],
+		function(i, val) {
+			$('#huge-text-smart-reposition .' + val).data('powertip', 'small text');
+			$('#huge-text-smart-reposition .' + val).hover(function() {
+				setTimeout(function() {
+					$('#powerTip').html(hugeText);
+					$('#huge-text-smart-reposition .' + val).powerTip('reposition');
+				}, 1000);
+			});
+		}
+	);
+
+	// Huge text with smart placement and reposition
+	$('#huge-text-smart-reposition .north').powerTip({ placement: 'n', smartPlacement: true });
+	$('#huge-text-smart-reposition .east').powerTip({ placement: 'e', smartPlacement: true });
+	$('#huge-text-smart-reposition .south').powerTip({ placement: 's', smartPlacement: true });
+	$('#huge-text-smart-reposition .west').powerTip({ placement: 'w', smartPlacement: true });
+	$('#huge-text-smart-reposition .north-west').powerTip({ placement: 'nw', smartPlacement: true });
+	$('#huge-text-smart-reposition .north-east').powerTip({ placement: 'ne', smartPlacement: true });
+	$('#huge-text-smart-reposition .south-west').powerTip({ placement: 'sw', smartPlacement: true });
+	$('#huge-text-smart-reposition .south-east').powerTip({ placement: 'se', smartPlacement: true });
+	$('#huge-text-smart-reposition .north-west-alt').powerTip({ placement: 'nw-alt', smartPlacement: true });
+	$('#huge-text-smart-reposition .north-east-alt').powerTip({ placement: 'ne-alt', smartPlacement: true });
+	$('#huge-text-smart-reposition .south-west-alt').powerTip({ placement: 'sw-alt', smartPlacement: true });
+	$('#huge-text-smart-reposition .south-east-alt').powerTip({ placement: 'se-alt', smartPlacement: true });
+
 	// SVG elements
 	$('#svg-elements #red-ellipse1').powerTip({ placement: 'n' });
 	$('#svg-elements #red-ellipse2').powerTip({ placement: 'e' });


### PR DESCRIPTION
If a reposition of a powertip with smart placement occurs which requires the powertip to change placement, multiple placement classes are added to the powertips, which breaks the display of the powertip arrow. 

Compare the test to current behavior for example. Test is meant to make the issue far more apparent than it is in normal use by asyncing in a huge text.


**Before:**
<img width="989" alt="screen shot 2016-03-29 at 8 41 16 am" src="https://cloud.githubusercontent.com/assets/1979887/14113982/24c5c840-f58a-11e5-96a1-54c697baab29.png">

**After:**
<img width="988" alt="screen shot 2016-03-29 at 8 41 43 am" src="https://cloud.githubusercontent.com/assets/1979887/14113977/193a97da-f58a-11e5-95ff-b912074edbf8.png">

Comments would be wholly appreciated.