### PR TITLE
Bug/old doctype positioning patch

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -57,16 +57,8 @@ function initTracking() {
 function getViewportDimensions() {
 	session.scrollLeft = $window.scrollLeft();
 	session.scrollTop = $window.scrollTop();
-	// When in quirks mode, because doctype missing or referencing older
-	// html standard, jquery not report viewport size properly
-	if (document.compatMode === 'BackCompat') {
-		session.windowWidth = document.body.clientWidth;
-		session.windowHeight = document.body.clientHeight;
-	} else {
-		session.windowWidth = $window.width();
-		session.windowHeight = $window.height();
-	}
-	session.positionCompensation = computePositionCompensation(session.windowWidth, session.windowHeight);
+
+	trackResize();
 }
 
 /**
@@ -75,7 +67,7 @@ function getViewportDimensions() {
  */
 function trackResize() {
 	// When in quirks mode, because doctype missing or referencing older
-	// html standard, jquery not report viewport size properly
+	// html standard, jquery does not report viewport size properly
 	if (document.compatMode === 'BackCompat') {
 		session.windowWidth = document.body.clientWidth;
 		session.windowHeight = document.body.clientHeight;
@@ -83,7 +75,6 @@ function trackResize() {
 		session.windowWidth = $window.width();
 		session.windowHeight = $window.height();
 	}
-	session.positionCompensation = computePositionCompensation(session.windowWidth, session.windowHeight);
 }
 
 /**

--- a/src/utility.js
+++ b/src/utility.js
@@ -57,8 +57,16 @@ function initTracking() {
 function getViewportDimensions() {
 	session.scrollLeft = $window.scrollLeft();
 	session.scrollTop = $window.scrollTop();
-	session.windowWidth = $window.width();
-	session.windowHeight = $window.height();
+	// When in quirks mode, because doctype missing or referencing older
+	// html standard, jquery not report viewport size properly
+	if (document.compatMode === 'BackCompat') {
+		session.windowWidth = document.body.clientWidth;
+		session.windowHeight = document.body.clientHeight;
+	} else {
+		session.windowWidth = $window.width();
+		session.windowHeight = $window.height();
+	}
+	session.positionCompensation = computePositionCompensation(session.windowWidth, session.windowHeight);
 }
 
 /**
@@ -66,8 +74,16 @@ function getViewportDimensions() {
  * @private
  */
 function trackResize() {
-	session.windowWidth = $window.width();
-	session.windowHeight = $window.height();
+	// When in quirks mode, because doctype missing or referencing older
+	// html standard, jquery not report viewport size properly
+	if (document.compatMode === 'BackCompat') {
+		session.windowWidth = document.body.clientWidth;
+		session.windowHeight = document.body.clientHeight;
+	} else {
+		session.windowWidth = $window.width();
+		session.windowHeight = $window.height();
+	}
+	session.positionCompensation = computePositionCompensation(session.windowWidth, session.windowHeight);
 }
 
 /**


### PR DESCRIPTION
When in BackCompat mode the viewport size was not reported correctly.

This is a patch I created some time ago to fix a problem identified during use.  It could probably use a test case to support it.