### PR TITLE
Change the arrow of the tooltip to same color as the tooltip.

### DIFF
--- a/css/jquery.powertip-blue.css
+++ b/css/jquery.powertip-blue.css
@@ -39,21 +39,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #4b91d2;
 	border-top: 10px solid rgba(75, 145, 210, 0.8);
+	border-top-color: inherit;	
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #4b91d2;
 	border-right: 10px solid rgba(75, 145, 210, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #4b91d2;
 	border-bottom: 10px solid rgba(75, 145, 210, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #4b91d2;
 	border-left: 10px solid rgba(75, 145, 210, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +73,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #4b91d2;
 	border-top: 10px solid rgba(75, 145, 210, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #4b91d2;
 	border-bottom: 10px solid rgba(75, 145, 210, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #4b91d2;
 	border-top: 10px solid rgba(75, 145, 210, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +100,7 @@
 	border-top: none;
 	border-bottom: 10px solid #4b91d2;
 	border-bottom: 10px solid rgba(75, 145, 210, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip-blue.css
+++ b/css/jquery.powertip-blue.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #a5d2fa inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #a5d2fa inset;
 	border: 1px solid #4b91d2;
+	border-color: #4b91d2;
 	border-radius: 6px;
 	color: #000000;
 	display: none;

--- a/css/jquery.powertip-dark.css
+++ b/css/jquery.powertip-dark.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.2) inset, 0 -2px 2px #323232 inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.2) inset, 0 -2px 2px #323232 inset;
 	border: 1px solid #000000;
+	border-color: #000000;
 	border-radius: 6px;
 	color: #ffffff;
 	display: none;
@@ -39,21 +40,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #000000;
 	border-top: 10px solid rgba(0, 0, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #000000;
 	border-right: 10px solid rgba(0, 0, 0, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #000000;
 	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #000000;
 	border-left: 10px solid rgba(0, 0, 0, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +74,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #000000;
 	border-top: 10px solid rgba(0, 0, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #000000;
 	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #000000;
 	border-top: 10px solid rgba(0, 0, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +101,7 @@
 	border-top: none;
 	border-bottom: 10px solid #000000;
 	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip-green.css
+++ b/css/jquery.powertip-green.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.8) inset, 0 -2px 2px #dcf582 inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.8) inset, 0 -2px 2px #dcf582 inset;
 	border: 1px solid #9bc800;
+	border-color: #9bc800;
 	border-radius: 6px;
 	color: #000000;
 	display: none;
@@ -39,21 +40,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #9bc800;
 	border-top: 10px solid rgba(155, 200, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #9bc800;
 	border-right: 10px solid rgba(155, 200, 0, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #9bc800;
 	border-bottom: 10px solid rgba(155, 200, 0, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #9bc800;
 	border-left: 10px solid rgba(155, 200, 0, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +74,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #9bc800;
 	border-top: 10px solid rgba(155, 200, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #9bc800;
 	border-bottom: 10px solid rgba(155, 200, 0, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #9bc800;
 	border-top: 10px solid rgba(155, 200, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +101,7 @@
 	border-top: none;
 	border-bottom: 10px solid #9bc800;
 	border-bottom: 10px solid rgba(155, 200, 0, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip-light.css
+++ b/css/jquery.powertip-light.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #dcdcdc inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #dcdcdc inset;
 	border: 1px solid #acacac;
+	border-color: #acacac;
 	border-radius: 6px;
 	color: #000000;
 	display: none;
@@ -39,21 +40,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #acacac;
 	border-top: 10px solid rgba(172, 172, 172, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #acacac;
 	border-right: 10px solid rgba(172, 172, 172, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #acacac;
 	border-bottom: 10px solid rgba(172, 172, 172, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #acacac;
 	border-left: 10px solid rgba(172, 172, 172, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +74,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #acacac;
 	border-top: 10px solid rgba(172, 172, 172, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #acacac;
 	border-bottom: 10px solid rgba(172, 172, 172, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #acacac;
 	border-top: 10px solid rgba(172, 172, 172, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +101,7 @@
 	border-top: none;
 	border-bottom: 10px solid #acacac;
 	border-bottom: 10px solid rgba(172, 172, 172, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip-orange.css
+++ b/css/jquery.powertip-orange.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #fab482 inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #fab482 inset;
 	border: 1px solid #f5a550;
+	border-color: #f5a550;
 	border-radius: 6px;
 	color: #000000;
 	display: none;
@@ -39,21 +40,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #f5a550;
 	border-top: 10px solid rgba(245, 165, 80, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #f5a550;
 	border-right: 10px solid rgba(245, 165, 80, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #f5a550;
 	border-bottom: 10px solid rgba(245, 165, 80, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #f5a550;
 	border-left: 10px solid rgba(245, 165, 80, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +74,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #f5a550;
 	border-top: 10px solid rgba(245, 165, 80, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #f5a550;
 	border-bottom: 10px solid rgba(245, 165, 80, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #f5a550;
 	border-top: 10px solid rgba(245, 165, 80, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +101,7 @@
 	border-top: none;
 	border-bottom: 10px solid #f5a550;
 	border-bottom: 10px solid rgba(245, 165, 80, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip-purple.css
+++ b/css/jquery.powertip-purple.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #d796ff inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #d796ff inset;
 	border: 1px solid #914bd2;
+	border-color: #914bd2;
 	border-radius: 6px;
 	color: #000000;
 	display: none;
@@ -39,21 +40,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #914bd2;
 	border-top: 10px solid rgba(145, 75, 210, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #914bd2;
 	border-right: 10px solid rgba(145, 75, 210, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #914bd2;
 	border-bottom: 10px solid rgba(145, 75, 210, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #914bd2;
 	border-left: 10px solid rgba(145, 75, 210, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +74,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #914bd2;
 	border-top: 10px solid rgba(145, 75, 210, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #914bd2;
 	border-bottom: 10px solid rgba(145, 75, 210, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #914bd2;
 	border-top: 10px solid rgba(145, 75, 210, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +101,7 @@
 	border-top: none;
 	border-bottom: 10px solid #914bd2;
 	border-bottom: 10px solid rgba(145, 75, 210, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip-red.css
+++ b/css/jquery.powertip-red.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #f5aa9b inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 2px #f5aa9b inset;
 	border: 1px solid #eb5037;
+	border-color: #eb5037;
 	border-radius: 6px;
 	color: #000000;
 	display: none;
@@ -39,21 +40,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #eb5037;
 	border-top: 10px solid rgba(235, 80, 55, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #eb5037;
 	border-right: 10px solid rgba(235, 80, 55, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #eb5037;
 	border-bottom: 10px solid rgba(235, 80, 55, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #eb5037;
 	border-left: 10px solid rgba(235, 80, 55, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +74,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #eb5037;
 	border-top: 10px solid rgba(235, 80, 55, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #eb5037;
 	border-bottom: 10px solid rgba(235, 80, 55, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #eb5037;
 	border-top: 10px solid rgba(235, 80, 55, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +101,7 @@
 	border-top: none;
 	border-bottom: 10px solid #eb5037;
 	border-bottom: 10px solid rgba(235, 80, 55, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip-yellow.css
+++ b/css/jquery.powertip-yellow.css
@@ -12,6 +12,7 @@
 	-moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.8) inset, 0 -2px 2px #fafa6e inset;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.15), 0 2px 1px rgba(255, 255, 255, 0.8) inset, 0 -2px 2px #fafa6e inset;
 	border: 1px solid #fafa50;
+	border-color: #fafa50;
 	border-radius: 6px;
 	color: #000000;
 	display: none;
@@ -39,21 +40,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #fafa50;
 	border-top: 10px solid rgba(250, 250, 80, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #fafa50;
 	border-right: 10px solid rgba(250, 250, 80, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #fafa50;
 	border-bottom: 10px solid rgba(250, 250, 80, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #fafa50;
 	border-left: 10px solid rgba(250, 250, 80, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -69,17 +74,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #fafa50;
 	border-top: 10px solid rgba(250, 250, 80, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #fafa50;
 	border-bottom: 10px solid rgba(250, 250, 80, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #fafa50;
 	border-top: 10px solid rgba(250, 250, 80, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -93,6 +101,7 @@
 	border-top: none;
 	border-bottom: 10px solid #fafa50;
 	border-bottom: 10px solid rgba(250, 250, 80, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }

--- a/css/jquery.powertip.css
+++ b/css/jquery.powertip.css
@@ -9,6 +9,7 @@
 	cursor: default;
 	background-color: #333;
 	background-color: rgba(0, 0, 0, 0.8);
+	border-color: rgba(0, 0, 0, 0.8);
 	border-radius: 6px;
 	color: #fff;
 	display: none;
@@ -36,21 +37,25 @@
 #powerTip.n:before {
 	border-top: 10px solid #333;
 	border-top: 10px solid rgba(0, 0, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.e:before {
 	border-right: 10px solid #333;
 	border-right: 10px solid rgba(0, 0, 0, 0.8);
+	border-right-color: inherit;
 	left: -10px;
 }
 #powerTip.s:before {
 	border-bottom: 10px solid #333;
 	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.w:before {
 	border-left: 10px solid #333;
 	border-left: 10px solid rgba(0, 0, 0, 0.8);
+	border-left-color: inherit;
 	right: -10px;
 }
 #powerTip.ne:before, #powerTip.se:before {
@@ -66,17 +71,20 @@
 #powerTip.ne:before, #powerTip.nw:before {
 	border-top: 10px solid #333;
 	border-top: 10px solid rgba(0, 0, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 }
 #powerTip.se:before, #powerTip.sw:before {
 	border-bottom: 10px solid #333;
 	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+	border-bottom-color: inherit;
 	top: -10px;
 }
 #powerTip.nw-alt:before, #powerTip.ne-alt:before,
 #powerTip.sw-alt:before, #powerTip.se-alt:before {
 	border-top: 10px solid #333;
 	border-top: 10px solid rgba(0, 0, 0, 0.8);
+	border-top-color: inherit;
 	bottom: -10px;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
@@ -90,6 +98,7 @@
 	border-top: none;
 	border-bottom: 10px solid #333;
 	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+	border-bottom-color: inherit;
 	bottom: auto;
 	top: -10px;
 }


### PR DESCRIPTION
The ability to add popupClass gives a great feature to add custom CSS to the tooltip. However, those custom changes do not apply to the arrow of the tooltip. This will help the arrow to inherit the border-color from the popupClass defined. 

If the popupClass is not defined, it will take the default style.