### PR TITLE
Fixes the positioning of a following tooltip in a horizontally scrolled document

### DIFF
--- a/src/tooltipcontroller.js
+++ b/src/tooltipcontroller.js
@@ -254,7 +254,7 @@ function TooltipController(options) {
 					// if there is only one collision (bottom or right) then
 					// simply constrain the tooltip to the view port
 					if (collisions === Collision.right) {
-						coords.set('left', session.windowWidth - tipWidth);
+						coords.set('left', session.scrollLeft + session.windowWidth - tipWidth);
 					} else if (collisions === Collision.bottom) {
 						coords.set('top', session.scrollTop + session.windowHeight - tipHeight);
 					}


### PR DESCRIPTION
Given a horizontally scrolled document (e.g. width=10000px) with a tooltip following the mouse and colliding with the right bound of the document will cause the tooltip to disappear / change the coordinates to windowWidth - tipWidth instead of the scrolling position of the document + windowWidth - tipWidth